### PR TITLE
Install ansible.cfg on jumpbox

### DIFF
--- a/files/ansible.cfg
+++ b/files/ansible.cfg
@@ -1,0 +1,30 @@
+# Ansible managed
+
+[defaults]
+# additional paths to search for roles in, colon separated
+roles_path = roles:roles/vendor:ansible/roles/vendor:ansible/roles
+
+# default user to use for playbooks if user is not specified
+# (/usr/bin/ansible will use current user as default)
+remote_user = ubuntu
+
+# logging is off by default unless this path is defined
+# if so defined, consider logrotate
+log_path = /var/log/ansible.log
+
+# If set, configures the path to the Vault password file as an alternative to
+# specifying --vault-password-file on the command line.
+vault_password_file = /etc/datagov/ansible-secret.txt
+
+# by default (as of 1.4), Ansible may display deprecation warnings for language
+# features that should no longer be used and will be removed in future versions.
+# to disable these warnings, set the following value to False:
+deprecation_warnings = False
+
+# don't like cows?  that's unfortunate.
+# set to 1 if you don't want cowsay support or export ANSIBLE_NOCOWS=1
+nocows = 1
+
+[privilege_escalation]
+become=True
+become_method=sudo

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -11,11 +11,36 @@ removeduser = 'removeduser'
 testuser_public_key = 'testuser-public-key-string'
 
 
+def test_operators_group(host):
+    operators = host.group('operators')
+
+    assert operators.exists
+
+
+def test_datagov_configuration_dir(host):
+    datagov = host.file('/etc/datagov')
+
+    assert datagov.is_directory
+    assert datagov.mode == 0o750
+    assert datagov.user == 'root'
+    assert datagov.group == 'operators'
+
+
+def test_ansible_cfg(host):
+    ansible_cfg = host.file('/etc/datagov/ansible.cfg')
+
+    assert ansible_cfg.is_file
+    assert ansible_cfg.mode == 0o644
+    assert ansible_cfg.user == 'root'
+    assert ansible_cfg.group == 'operators'
+
+
 def test_user_created(host):
     user = host.user(testuser)
 
     assert user.expiration_date is None
     assert user.home
+    assert 'operators' in user.groups
     assert user.shell == '/bin/bash'
     assert user.password == '!', 'user password should be locked'
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,10 +12,21 @@
     - python-pip
     - python-virtualenv
 
+- name: Create operators group
+  group: name=operators state=present
+
+- name: Create data.gov configuration directory
+  file: path=/etc/datagov state=directory owner=root group=operators mode=0750
+
+- name: Configure ansible
+  copy: src=ansible.cfg dest=/etc/datagov/ansible.cfg owner=root group=operators mode=0644
+
 - name: Create/remove the user account
   user:
     name: "{{ item.username }}"
     comment: "{{ item.email }}"
+    groups:
+      - operators
     shell: /bin/bash
     state: "{{ item.removed is defined and 'absent' or 'present' }}"
     password_lock: yes


### PR DESCRIPTION
This moves us closer to having independent operator accounts on the jumpbox, avoiding having to `sudo -u ubuntu` for tasks.

This lets us remove the ansible.cfg from datagov-deploy, and avoids hardcoding the ansible vault secret  to the home directory. This also lets us install the vault key to a central place on the jumpbox (/etc/datagov/ansible-secret.txt) so that it is available for all operators.