### PR TITLE
Refactor operators, default to inactive

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -11,3 +11,6 @@ molecule = {extras = ["docker"],version = "*"}
 
 [requires]
 python_version = "3.6"
+
+[scripts]
+test = "molecule test"

--- a/README.md
+++ b/README.md
@@ -34,6 +34,20 @@ Example Playbook
 **jumpbox_operators** list<object>
 
 The user accounts to create on the jumpbox. User objects should include
-a `username`, `email`, and `public_key` (contents of the users id_rsa.pub). The
-authorized_keys is set exclusively to this key, so any modifications to
-authorized_keys will be overridden the next time this role is run.
+a `username`, `email`, `public_key` (contents of the users id_rsa.pub), and
+`active`. The user's `authorized_keys` is set exclusively to this key, so any modifications to
+`authorized_keys` will be overridden the next time this role is run.
+
+```
+jumpbox_operators:
+  - username: userone
+    email: userone@example.com
+    public_key: ssh-rsa aabbccddeeff1234567890 comment
+    active: true
+```
+
+- `username` (required) name of the user account to create
+- `email` (required) email address of the user
+- `public_key` (required) the public SSH key for the user (contents of
+  id_rsa.pub)
+- `active` (default: false) active users are created, inactive users are removed

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -25,10 +25,10 @@ provisioner:
           - username: testuser
             email: testuser@example.com
             public_key: ssh-rsa testuser-public-key-string comment
-          - username: removeduser
-            email: removeduser@example.com
-            public_key: ssh-rsa removeduser-public-key-string comment
-            removed: true
+            active: true
+          - username: inactiveuser
+            email: inactiveuser@example.com
+            public_key: ssh-rsa inactiveuser-public-key-string comment
 scenario:
   name: default
   test_sequence:

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -10,5 +10,14 @@
         state: present
         password_lock: yes
         expires: -1
-    - name: update apt
-      apt: update_cache=true
+
+    - name: install aptitude for ansible
+      apt: name=aptitude state=present cache_valid_time=3600
+
+    - name: create inactive user as active (to be removed)
+      user:
+        name: inactiveuser
+        state: present
+
+    - name: add inactive user to sudoers (to be removed)
+      file: path=/etc/sudoers.d/inactiveuser state=touch owner=root group=root

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -7,7 +7,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 
 testuser = 'testuser'
-removeduser = 'removeduser'
+inactiveuser = 'inactiveuser'
 testuser_public_key = 'testuser-public-key-string'
 
 
@@ -28,10 +28,12 @@ def test_authorized_keys(host):
     assert authorized_keys.contains(testuser_public_key)
 
 
-def test_removed_user(host):
+def test_inactive_user(host):
     passwd = host.file('/etc/passwd')
+    sudoers = host.file('/etc/sudoers.d/inactiveuser')
 
-    assert not passwd.contains(removeduser)
+    assert not passwd.contains(inactiveuser)
+    assert not sudoers.exists
 
 
 def test_dsh_all_group(host):

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,7 +17,7 @@
     name: "{{ item.username }}"
     comment: "{{ item.email }}"
     shell: /bin/bash
-    state: "{{ item.removed is defined and 'absent' or 'present' }}"
+    state: "{{ item.active | default(false) | ternary('present', 'absent') }}"
     password_lock: yes
     expires: -1
   with_items: "{{ jumpbox_operators }}"
@@ -29,7 +29,7 @@
     mode=0700
     owner={{ item.username }}
     group={{ item.username }}
-  when: item.removed is undefined
+  when: item.active | default(false)
   with_items: "{{ jumpbox_operators }}"
 
 - name: Add SSH public key directory structure for ubuntu
@@ -46,7 +46,7 @@
     key: "{{ item.public_key }}"
     exclusive: True
     state: "present"
-  when: item.removed is not defined
+  when: item.active | default(false)
   with_items: "{{ jumpbox_operators }}"
 
 - name: Update ssh config with inventory for auto completion
@@ -57,7 +57,7 @@
     group: "{{ item.username }}"
     mode: 0640
     force: no
-  when: item.removed is not defined
+  when: item.active | default(false)
   with_items: "{{ jumpbox_operators }}"
 
 - name: Update ssh config with inventory for auto completion for ubuntu user
@@ -74,14 +74,14 @@
     src=sudoers.j2
     dest=/etc/sudoers.d/{{ item.username }}
     mode=0600
-  when: item.removed is not defined
+  when: item.active | default(false)
   with_items: "{{ jumpbox_operators }}"
 
-- name: Remove sudoers for removed users
+- name: Remove inactive users from sudoers
   file: >-
     dest=/etc/sudoers.d/{{ item.username }}
     state=absent
-  when: item.removed is defined
+  when: not (item.active | default(false))
   with_items: "{{ jumpbox_operators }}"
 
 - name: Configure dsh

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,16 +1,17 @@
 ---
 - name: install jumpbox packages
-  apt: name={{ item }} update_cache=yes state=present
-  with_items:
-    # These are mostly dependencies for datagov-deploy's requirements.txt
-    - dsh
-    - git
-    - libffi-dev
-    - libssl-dev
-    - openssh-server
-    - python-dev
-    - python-pip
-    - python-virtualenv
+  apt: name={{ packages }} update_cache=yes state=present
+  vars:
+    packages:
+      # These are mostly dependencies for datagov-deploy's requirements.txt
+      - dsh
+      - git
+      - libffi-dev
+      - libssl-dev
+      - openssh-server
+      - python-dev
+      - python-pip
+      - python-virtualenv
 
 - name: Create/remove the user account
   user:


### PR DESCRIPTION
@pburkholder 's suggestion to default operators to inactive and require explicit `active: true`. This makes it a bit "safer" when attempting to remove access for an operator (since the default is no access).