### PR TITLE
Disable password expiration

### DIFF
--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -1,4 +1,5 @@
 import os
+import re
 
 import testinfra.utils.ansible_runner
 
@@ -59,6 +60,14 @@ def test_inactive_user(host):
 
     assert not passwd.contains(inactiveuser)
     assert not sudoers.exists
+
+
+def test_chage(host):
+    chage = host.check_output('chage -l testuser')
+
+    assert re.search(r'Account expires\s+: never', chage)
+    assert re.search(r'Password expires\s+: never', chage)
+    assert re.search(r'Password inactive\s+: never', chage)
 
 
 def test_dsh_all_group(host):

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -39,7 +39,7 @@
   command: chage -I -1 -M -1 {{ item.item.username }}
   with_items: "{{ user_account.results }}"
   when:
-    - item.item.active | default(true)
+    - item.item.active | default(false)
     - item is changed
 
 - name: Add SSH public key directory structure

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,6 +33,14 @@
     password_lock: yes
     expires: -1
   with_items: "{{ jumpbox_operators }}"
+  register: user_account
+
+- name: Disable password max age
+  command: chage -I -1 -M -1 {{ item.item.username }}
+  with_items: "{{ user_account.results }}"
+  when:
+    - item.item.active | default(true)
+    - item is changed
 
 - name: Add SSH public key directory structure
   file: >-


### PR DESCRIPTION
https://github.com/GSA/datagov-deploy/issues/1320

Passwords are locked and password login is disabled. The password policy causes
users to get locked out. Disable the password expiration for operators.