### PR TITLE
Add ubuntu to the operators group

### DIFF
--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -17,6 +17,17 @@ def test_operators_group(host):
     assert operators.exists
 
 
+def test_ubuntu_user(host):
+    """Test ubuntu user exists and is part of the operators group."""
+    user = host.user('ubuntu')
+
+    assert user.exists
+    assert 'operators' in user.groups
+    assert 'ubuntu' in user.groups
+    assert user.expiration_date is None
+    assert user.password == '!', 'user password should be locked'
+
+
 def test_datagov_configuration_dir(host):
     datagov = host.file('/etc/datagov')
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,13 +16,19 @@
 - name: Create operators group
   group: name=operators state=present
 
+- name: Add ubuntu user to operators group
+  user:
+    name: ubuntu
+    groups:
+      - operators
+
 - name: Create data.gov configuration directory
   file: path=/etc/datagov state=directory owner=root group=operators mode=0750
 
 - name: Configure ansible
   copy: src=ansible.cfg dest=/etc/datagov/ansible.cfg owner=root group=operators mode=0644
 
-- name: Create/remove the user account
+- name: Create operator accounts
   user:
     name: "{{ item.username }}"
     comment: "{{ item.email }}"
@@ -35,10 +41,10 @@
   with_items: "{{ jumpbox_operators }}"
   register: user_account
 
-- name: Determine existing users
+- name: Determine existing operators
   shell: |
     set -o pipefail
-    grep operators /etc/group | cut -d: -f4 | tr "," "\n"
+    grep operators /etc/group | cut -d: -f4 | tr "," "\n" | grep -v "^ubuntu$"
   args:
     executable: /bin/bash
   changed_when: false


### PR DESCRIPTION
This allows the ubuntu user access to /etc/datagov, so all users are sharing the
same vault keys and configuration. This makes the ubuntu user less of a special
case.